### PR TITLE
 Android 12 Firebase dynamic link was not well handled

### DIFF
--- a/app_links/android/src/main/java/com/llfbandit/app_links/AppLinksHelper.java
+++ b/app_links/android/src/main/java/com/llfbandit/app_links/AppLinksHelper.java
@@ -1,0 +1,102 @@
+package com.llfbandit.app_links;
+
+import android.content.Intent;
+import android.os.Parcel;
+import android.util.Log;
+import androidx.annotation.NonNull;
+
+public class AppLinksHelper {
+    private static final String EXTRA_DATA_NAME = "com.google.firebase.dynamiclinks.DYNAMIC_LINK_DATA";
+
+    private static final String TAG = "com.llfbandit.app_links";
+
+    public String getDeepLinkFromIntent(Intent intent) {
+        String shortLink = getShortDeepLink(intent);
+
+        if (shortLink != null) {
+            Log.d(TAG, "handleIntent: (Data) (short deep link)" + shortLink);
+            return shortLink;
+        }
+
+
+        return getUrl(intent);
+    }
+
+    private String getShortDeepLink(Intent intent) {
+        byte[] bytes = intent.getByteArrayExtra(EXTRA_DATA_NAME);
+        Parcel parcel = Parcel.obtain();
+        parcel.unmarshall(bytes, 0, bytes.length);
+        parcel.setDataPosition(0);
+
+        int end = validateObjectHeader(parcel);
+
+        while (parcel.dataPosition() < end) {
+            int header = parcel.readInt();
+            switch (getFieldId(header)) {
+                case 1:
+                case 2:
+                    String shortLink = createString(parcel, header);
+                    return shortLink;
+                default:
+                    Log.d(TAG, "Nothing to show");
+                    break;
+            }
+        }
+
+        return null;
+    }
+
+    private String getUrl(Intent intent) {
+        String action = intent.getAction();
+        String dataString = intent.getDataString();
+
+        Log.d(TAG, "handleIntent: (Action) " + action);
+        Log.d(TAG, "handleIntent: (Data) " + dataString);
+
+        return dataString;
+    }
+
+    private int readSize(Parcel parcel, int header) {
+        if ((header & 0xFFFF0000) != 0xFFFF0000)
+            return header >> 16 & 0xFFFF;
+        return parcel.readInt();
+    }
+
+    public int validateObjectHeader(@NonNull Parcel p) {
+        int var1 = p.readInt();
+        int var2 = readSize(p, var1);
+        int var3 = p.dataPosition();
+        if (getFieldId(var1) != 20293) {
+            throw new NullPointerException();
+        } else {
+            var1 = var3 + var2;
+            if (var1 >= var3 && var1 <= p.dataSize()) {
+                return var1;
+            } else {
+                StringBuilder var4 = new StringBuilder();
+                var4.append("Size read is invalid start=");
+                var4.append(var3);
+                var4.append(" end=");
+                var4.append(var1);
+                throw new NullPointerException();
+            }
+        }
+    }
+
+    private int getFieldId(int header) {
+        return header & 0xFFFF;
+    }
+
+    @NonNull
+    private String createString(@NonNull Parcel p, int header) {
+        header = readSize(p, header);
+        int var2 = p.dataPosition();
+        if (header == 0) {
+            return null;
+        } else {
+            String var3 = p.readString();
+            p.setDataPosition(var2 + header);
+            return var3;
+        }
+    }
+}

--- a/app_links/android/src/main/java/com/llfbandit/app_links/AppLinksPlugin.java
+++ b/app_links/android/src/main/java/com/llfbandit/app_links/AppLinksPlugin.java
@@ -2,6 +2,7 @@ package com.llfbandit.app_links;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Parcel;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -28,8 +29,8 @@ public class AppLinksPlugin implements
 
   private static final String MESSAGES_CHANNEL = "com.llfbandit.app_links/messages";
   private static final String EVENTS_CHANNEL = "com.llfbandit.app_links/events";
-
   private static final String TAG = "com.llfbandit.app_links";
+  private static final String EXTRA_DATA_NAME = "com.google.firebase.dynamiclinks.DYNAMIC_LINK_DATA";
 
   // The MethodChannel that will the communication between Flutter and native
   // Android
@@ -170,11 +171,9 @@ public class AppLinksPlugin implements
       return false;
     }
 
-    String action = intent.getAction();
-    String dataString = intent.getDataString();
+    AppLinksHelper helper = new AppLinksHelper();
 
-    Log.d(TAG, "handleIntent: (Action) " + action);
-    Log.d(TAG, "handleIntent: (Data) " + dataString);
+    String dataString = helper.getDeepLinkFromIntent(intent);
 
     if (dataString != null) {
       if (initialLink == null) {
@@ -189,6 +188,7 @@ public class AppLinksPlugin implements
 
     return false;
   }
+
   ///
   /// END AppLinksPlugin
   /////////////////////////////////////////////////////////////////////////////

--- a/app_links/example/windows/flutter/generated_plugins.cmake
+++ b/app_links/example/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,9 @@ list(APPEND FLUTTER_PLUGIN_LIST
   app_links_windows
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -14,3 +17,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)


### PR DESCRIPTION
The deeplink created by firebase was not well handled for Android 12 and above. 

A firebase deeplink is composed by a short link (who should be received by the app) and a link (this link is used when the user do not have the app installed on his device).
Before Android 12 the short link was send to the app but from Android 12 and above the link was send to the app, so it break the deeplink behavior on some apps. This PR fix this and always send the correct link.