### PR TITLE
[proposal] add `setInitialLink` setter on iOS

### DIFF
--- a/ios/Classes/SwiftAppLinksPlugin.swift
+++ b/ios/Classes/SwiftAppLinksPlugin.swift
@@ -7,6 +7,12 @@ public class SwiftAppLinksPlugin: NSObject, FlutterPlugin, FlutterStreamHandler 
   fileprivate var initialLink: String?
   fileprivate var latestLink: String?
 
+  // Set the initial link manually
+  // c.f #47
+  public static func setInitialLink(url: URL) -> Void {
+    SwiftAppLinksCustom.shared.initialLink = url.absoluteString
+  }
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     let methodChannel = FlutterMethodChannel(name: "com.llfbandit.app_links/messages", binaryMessenger: registrar.messenger())
     let eventChannel = FlutterEventChannel(name: "com.llfbandit.app_links/events", binaryMessenger: registrar.messenger())
@@ -21,7 +27,8 @@ public class SwiftAppLinksPlugin: NSObject, FlutterPlugin, FlutterStreamHandler 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
       case "getInitialAppLink":
-        result(initialLink)
+        // return initialLink or manually stored value if null
+        result(initialLink ?? SwiftAppLinksCustom.shared.initialLink)
         break
       case "getLatestAppLink":
         result(latestLink)
@@ -89,4 +96,14 @@ public class SwiftAppLinksPlugin: NSObject, FlutterPlugin, FlutterStreamHandler 
 
     _eventSink(latestLink)
   }
+}
+
+// Store the values set manually in a Singleton
+// c.f #47
+class SwiftAppLinksCustom {
+  static let shared = SwiftAppLinksCustom()
+
+  var initialLink: String?
+
+  private init() {}
 }


### PR DESCRIPTION
This PR is made in order to fix #47.

I'm not sure where this problem really originated, and it's likely not directly from this library. But this PR offers an easy to use solution for people facing this problem (i.e. me for now).

Instead of using [this solution](https://github.com/llfbandit/app_links/issues/47#issuecomment-1459648752), this PR would be quite easier :

```swift
override func application(
    _ application: UIApplication,
    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
  ) -> Bool {
    // .. HERE do other stuff if needed

    // Custom URL
    if let url = launchOptions?[UIApplication.LaunchOptionsKey.url] as? URL {
      if(url.absoluteString.hasPrefix("myapp://")) {
        SwiftAppLinksPlugin.setInitialLink(url: url)
      }
    }
    // Universal link
    else if let activityDictionary = launchOptions?[UIApplication.LaunchOptionsKey.userActivityDictionary] as? [AnyHashable: Any] { 
      for key in activityDictionary.keys {
        if let userActivity = activityDictionary[key] as? NSUserActivity {
          if let url = userActivity.webpageURL {
            if(url.absoluteString.hasPrefix("https://mywebsite.com")) {
              SwiftAppLinksPlugin.setInitialLink(url: url)
              break
            }
          }
        }
      }
    }

    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
  }
```

As I said, the direct cause of this problem has not been identified, so I will understand if you wish to reject this PR.
Also, I don't know much about swift development so this might be optimizable.