### PR TITLE
Remove unnecessary break statements

### DIFF
--- a/ios/Classes/SwiftAppLinksPlugin.swift
+++ b/ios/Classes/SwiftAppLinksPlugin.swift
@@ -22,13 +22,10 @@ public class SwiftAppLinksPlugin: NSObject, FlutterPlugin, FlutterStreamHandler 
     switch call.method {
       case "getInitialAppLink":
         result(initialLink)
-        break
       case "getLatestAppLink":
         result(latestLink)
-        break      
       default:
         result(FlutterMethodNotImplemented)
-        break
     }
   }
 


### PR DESCRIPTION
In Swift, there is no implicit fallthrough - so there's no need for these `break` statements.

See https://docs.swift.org/swift-book/documentation/the-swift-programming-language/controlflow/#No-Implicit-Fallthrough