### PR TITLE
Update build.gradle to add support for Android Gradle Plugin 8.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dependencies {
         // https://developer.android.com/studio/releases/gradle-plugin
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 
@@ -24,6 +24,8 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 31
+    
+    namespace 'com.llfbandit.app_links'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
When building my app using this library with Gradle 8.1 and AGP 8.0.1, I encountered this error:

A problem occurred configuring project ':app_links'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified.

This is a breaking required change for AGP 8.0.1, which is available only from AGP 7.3, so I also updated to AGP 7.3.1, which is compatible with currently used Gradle Wrapper.