### PR TITLE
remove debugPrint from native platform SwiftAppLinksPlugin.swift

### DIFF
--- a/ios/Classes/SwiftAppLinksPlugin.swift
+++ b/ios/Classes/SwiftAppLinksPlugin.swift
@@ -72,8 +72,6 @@ public final class SwiftAppLinksPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   private func handleLink(url: URL) -> Void {
     let link = url.absoluteString
 
-    debugPrint("iOS handleLink: \(link)")
-
     latestLink = link
 
     if (initialLink == nil) {


### PR DESCRIPTION
I noticed this has logs coming from native platform that we cannot disable. We can log these items on Dart, so I'd like to propose that we remove this even though it's only on debug mode