### PR TITLE
feat(web): Support compilation to Wasm 

### DIFF
--- a/lib/src/app_links_web.dart
+++ b/lib/src/app_links_web.dart
@@ -1,4 +1,4 @@
-import 'dart:html';
+import 'package:web/web.dart' as web;
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:app_links/src/app_links_platform_interface.dart';
@@ -8,7 +8,7 @@ class AppLinksPluginWeb extends AppLinksPlatform {
     AppLinksPlatform.instance = AppLinksPluginWeb();
   }
 
-  final _initialLink = window.location.href;
+  final _initialLink = web.window.location.href;
 
   @override
   Future<Uri?> getInitialAppLink() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/llfbandit/app_links
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
 
   # https://pub.dev/packages/plugin_platform_interface
   plugin_platform_interface: ^2.0.0
-  web: ^0.5.1
+  web: ">=0.3.0 <0.6.0"
   flutter_web_plugins:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 3.5.1
 homepage: https://github.com/llfbandit/app_links
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
-  flutter: ">=3.0.0"
+  sdk: ">=3.2.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
 
   # https://pub.dev/packages/plugin_platform_interface
   plugin_platform_interface: ^2.0.0
-
+  web: ^0.5.1
   flutter_web_plugins:
     sdk: flutter
 


### PR DESCRIPTION
This PR migrates usage of dart:html to their new replacements. It also updates version constraints to account for the versions required. These changes enable compilation to Wasm and improves compatibility with Dart's evolving web interop story. 

The new package web requires flutter 3.16.0, therefore I updated the version constraints.

Dart and Flutter will prefer dart:js_interop, extension types, and package:web as used here going forward. Check out https://dart.dev/interop/js-interop/package-web to learn more.