### PR TITLE
Upgrade `web` dependency to prevent package downgrade in projects with `web` as a transitive dependency

### DIFF
--- a/app_links_web/pubspec.yaml
+++ b/app_links_web/pubspec.yaml
@@ -12,10 +12,10 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  
+
   app_links_platform_interface: ^2.0.0
 
-  web: ">=0.3.0 <0.6.0"
+  web: ">=0.3.0 <2.0.0"
 
 dev_dependencies:
   flutter_lints: ^4.0.0
@@ -26,4 +26,4 @@ flutter:
     platforms:
       web:
         pluginClass: AppLinksPluginWeb
-        fileName: 'app_links_web.dart'
+        fileName: "app_links_web.dart"


### PR DESCRIPTION
Currently, many packages force an upgrade to `web:: ^1.0.0` which causes `app_links` to be downgraded to `3.5.1 `. Of course this blocks WASM compilation. The breaking changes of `web` don't affect `app_links_web`.