### PR TITLE
fix(windows): Prevent other plugins from handling WM_COMMAND message.fixes

### DIFF
--- a/app_links/windows/app_links_plugin.cpp
+++ b/app_links/windows/app_links_plugin.cpp
@@ -137,13 +137,8 @@ namespace applinks
 		if (message == WM_COMMAND)
 		{
 			int wmId = LOWORD(wparam);
-			switch (wmId)
-			{
-			case IDM_GETARGSWAS:
+			if (wmId == IDM_GETARGSWAS) {
 				SendAppLink(hwnd);
-				break;
-			default:
-				return DefWindowProc(hwnd, message, wparam, lparam);
 			}
 		}
 


### PR DESCRIPTION
Fixes #175 

The current version breaks at least two plugins, `tray_manager` and `contextual_menu`. Please merge and release a new version as soon as possible.