### PR TITLE
- add reset Values of initialLink and latestLink To Null to avoid get …

### DIFF
--- a/app_links/android/src/main/java/com/llfbandit/app_links/AppLinksPlugin.java
+++ b/app_links/android/src/main/java/com/llfbandit/app_links/AppLinksPlugin.java
@@ -182,7 +182,15 @@ public class AppLinksPlugin implements
       eventSink.success(dataString);
     }
 
+    Log.d(TAG, "restValuesToNull///handleIntent");
+    restValuesToNull();
+
     return true;
+  }
+
+  void restValuesToNull() {
+    initialLink = null;
+    latestLink = null;
   }
 
   ///


### PR DESCRIPTION
- add reset Values of initialLink and latestLink in AppLinksPlugin.java To Null to avoid get old values when hot restart of android flutter app.